### PR TITLE
Fix: Ensure "Clear All App Data" removes all localStorage items

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1351,22 +1351,19 @@ function setupEventListeners() {
         });
     });
 
-    if (clearCacheBtn) {
-        clearCacheBtn.addEventListener('click', () => {
-            if (window.confirm(translations[currentLang].confirmClearCache)) {
-                localStorage.removeItem(CACHE_KEY);
-                localStorage.removeItem(LOCKED_POKEMON_CACHE_KEY);
-                localStorage.removeItem(FILTER_STATE_CACHE_KEY);
-                localStorage.removeItem(TEAM_MEMBERS_CACHE_KEY);
-                localStorage.removeItem(SHINY_POKEMON_CACHE_KEY);
-                localStorage.removeItem('darkMode');
-                localStorage.removeItem('language');
-                // localStorage.removeItem('pokemonCount'); // Clear count if saved
-                alert(translations[currentLang].cacheCleared);
-                window.location.reload();
-            }
-        });
-    }
+if (clearCacheBtn) {
+    clearCacheBtn.addEventListener('click', () => {
+        if (window.confirm(translations[currentLang].confirmClearCache)) {
+            // Clear all items from localStorage for the current origin
+            Object.keys(localStorage).forEach(key => {
+                localStorage.removeItem(key);
+            });
+            localStorage.removeItem('pokemonCount'); // Clear count if saved
+            alert(translations[currentLang].cacheCleared);
+            window.location.reload();
+        }
+    });
+}
 
     if (toggleAnalysisViewBtn) {
         toggleAnalysisViewBtn.addEventListener('click', () => {


### PR DESCRIPTION
The "Clear All App Data" button was previously only removing a predefined list of localStorage keys. This change updates the functionality to iterate over all keys in localStorage for the application's origin and remove them.

This ensures that all data, including potentially unknown or future keys, is cleared as expected. The `pokemonCount` key, which was previously commented out in the clearing process, is also now explicitly removed.

The decision was made not to uncomment the saving/loading mechanism for `pokemonCount` at this time, as the primary issue was related to data clearing, not persistence features.